### PR TITLE
Install dmd and dub version 2.085.1 for fixing dependency resolition bug

### DIFF
--- a/Dockerfile.multi
+++ b/Dockerfile.multi
@@ -2,14 +2,17 @@ FROM ubuntu:cosmic AS build
 
 RUN \
   apt-get update && \
-  apt-get install -y ldc gcc dub zlib1g-dev libssl-dev && \
+  apt-get install -y xz-utils gpg curl ldc gcc dub zlib1g-dev libssl-dev && \
   rm -rf /var/lib/apt/lists/*
+
+RUN \
+  curl -fsS https://dlang.org/install.sh | bash -s install dmd-2.085.1
 
 COPY . /tmp
 
 WORKDIR /tmp
 
-RUN dub -v build
+RUN . ~/dlang/dmd-2.085.1/activate && dub -v build
 
 FROM ubuntu:cosmic
 


### PR DESCRIPTION
Fixes dub error:

```
The dependency resolution process is taking too long. The 
dependency graph is likely hitting a pathological case in the 
resolution algorithm. Please file a bug report at 
https://github.com/dlang/dub/issues and mention the package 
recipe that reproduces this error.
```

For fixing error, add fresh versions of dmd and dub. Dmd and dub versions are fixed to 2.085.1 for reproducible builds.

See discussion here: https://forum.dlang.org/post/zhkbhhschqlflzvvsley@forum.dlang.org